### PR TITLE
解决maven版本依赖版本编译异常错误

### DIFF
--- a/thinking-in-spring/generic/pom.xml
+++ b/thinking-in-spring/generic/pom.xml
@@ -16,4 +16,17 @@
         <spring.version>4.3.26.RELEASE</spring.version>
     </properties>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-core</artifactId>
+            <version>4.3.26.RELEASE</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webflux</artifactId>
+            <version>5.2.2.RELEASE</version>
+        </dependency>
+    </dependencies>
+
 </project>


### PR DESCRIPTION
1.spring-webflux V5.X版本之后才有，现通过maven管理依赖将版本设定为“4.3.26.RELEASE”，maven编译异常错误；
2.引入“spring-core” 版本4.3.26.RELEASE， 因为代码需要“org.springframework.core.GenericCollectionTypeResolver”